### PR TITLE
Add error strings to US Buildings vector tile output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-index.html
-index.js
-package.html
-lib
-site/
 docs/_build/
 .cluster_id
 
@@ -35,9 +30,6 @@ _SUCCESS
 *.swo
 *.sublime-*
 
-lib
-index.html
-index.js
 .ensime*
 
 nohup.out
@@ -45,3 +37,5 @@ nohup.out
 derby.log
 metastore_db/
 *.log
+
+access-token.js

--- a/build.sbt
+++ b/build.sbt
@@ -102,6 +102,7 @@ sparkClusterName            := s"geotrellis-usbuildings"
 sparkEmrServiceRole         := "EMR_DefaultRole"
 sparkInstanceRole           := "EMR_EC2_DefaultRole"
 sparkJobFlowInstancesConfig := sparkJobFlowInstancesConfig.value.withEc2KeyName("geotrellis-emr")
+sparkS3LogUri               := Some("s3://geotrellis-test/usbuildings/logs")
 sparkEmrConfigs             := List(
   EmrConfig("spark").withProperties(
     "maximizeResourceAllocation" -> "true"

--- a/demo/access-token.js.example
+++ b/demo/access-token.js.example
@@ -1,0 +1,3 @@
+// Copy this file to ./access-token.js and then add your access token to ./access-token.js
+// before running the demo
+mapboxgl.accessToken = '<your-access-token-here>';

--- a/demo/index.html
+++ b/demo/index.html
@@ -19,8 +19,13 @@
 var map = new mapboxgl.Map({
     container: 'map',
     style: 'mapbox://styles/mapbox/light-v9',
-    zoom: 12,
-    center: [-73.2121, 44.4759]
+    zoom: 15,
+    center: [-79.9998879185631, 40.44117188556086]
+});
+
+var popup = new mapboxgl.Popup({
+    closeButton: false,
+    closeOnClick: false
 });
 
 map.on('load', function() {
@@ -28,38 +33,50 @@ map.on('load', function() {
     // https://www.mapillary.com/developer/tiles-documentation/#sequence-layer
     map.addLayer({
         "id": "mapillary",
-        "type": "line",
+        "type": "fill",
         "source": {
             "type": "vector",
-            "tiles": ["https://s3.amazonaws.com/geotrellis-test/usbuildings/afinkmiller-spark-ri01/{z}/{x}/{y}.mvt"],
+            "tiles": ["https://s3.amazonaws.com/geotrellis-test/usbuildings/afinkmiller-spark-pa01/{z}/{x}/{y}.mvt"],
             "minzoom": 15,
             "maxzoom": 15
         },
         "source-layer": "buildings",
-        "layout": {
-            "line-cap": "round",
-            "line-join": "round"
-        },
         "paint": {
-            "line-opacity": 0.6,
-            "line-color": [
+            "fill-opacity": 0.2,
+            "fill-color": [
                 "match",
                 ["get", "errors"],
                 "", "rgb(53, 175, 109)",
                 "red"
-            ],
-            "line-width": 2
+            ]
         }
     }, 'waterway-label');
 });
 
-map.on("mousemove", "mapillary", function(e) {
-    var osm_info = {
-      "min": e.features[0].properties["elevation_min"],
-      "max": e.features[0].properties["elevation_max"]
+map.on("mouseenter", "mapillary", function(e) {
+    map.getCanvas().style.cursor = 'pointer';
+    if (e.features && e.features[0] && e.features[0].properties) {
+        var feature = e.features[0];
+        var props = feature.properties;
+        var osm_info = {
+            "min": props["elevation_min"],
+            "max": props["elevation_max"]
+        };
+        if (props.errors) {
+            osm_info["errors"] = props["errors"]
+            var coordinates = feature.geometry.coordinates[0][0].slice();
+            popup.setLngLat(coordinates);
+            popup.setHTML(props["errors"]);
+            popup.addTo(map);
+        }
+        console.log(osm_info)
     }
-    console.log(e.features[0].properties, osm_info)
-  });
+});
+
+map.on("mouseleave", "mapillary", function (e) {
+    map.getCanvas().style.cursor = '';
+    popup.remove();
+});
 
 map.addControl(new mapboxgl.NavigationControl());
 </script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8' />
+    <title>Add a third party vector tile source</title>
+    <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='./access-token.js' type="text/javascript"></script>
+    <style>
+        body { margin:0; padding:0; }
+        #map { position:absolute; top:0; bottom:0; width:100%; }
+    </style>
+</head>
+<body>
+
+<div id='map'></div>
+<script>
+var map = new mapboxgl.Map({
+    container: 'map',
+    style: 'mapbox://styles/mapbox/light-v9',
+    zoom: 12,
+    center: [-73.2121, 44.4759]
+});
+
+map.on('load', function() {
+    // Add Mapillary sequence layer.
+    // https://www.mapillary.com/developer/tiles-documentation/#sequence-layer
+    map.addLayer({
+        "id": "mapillary",
+        "type": "line",
+        "source": {
+            "type": "vector",
+            "tiles": ["https://s3.amazonaws.com/geotrellis-test/usbuildings/afinkmiller-spark-ri01/{z}/{x}/{y}.mvt"],
+            "minzoom": 15,
+            "maxzoom": 15
+        },
+        "source-layer": "buildings",
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round"
+        },
+        "paint": {
+            "line-opacity": 0.6,
+            "line-color": [
+                "match",
+                ["get", "errors"],
+                "", "rgb(53, 175, 109)",
+                "red"
+            ],
+            "line-width": 2
+        }
+    }, 'waterway-label');
+});
+
+map.on("mousemove", "mapillary", function(e) {
+    var osm_info = {
+      "min": e.features[0].properties["elevation_min"],
+      "max": e.features[0].properties["elevation_max"]
+    }
+    console.log(e.features[0].properties, osm_info)
+  });
+
+map.addControl(new mapboxgl.NavigationControl());
+</script>
+
+</body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -36,7 +36,7 @@ map.on('load', function() {
         "type": "fill",
         "source": {
             "type": "vector",
-            "tiles": ["https://s3.amazonaws.com/geotrellis-test/usbuildings/afinkmiller-spark-pa01/{z}/{x}/{y}.mvt"],
+            "tiles": ["https://s3.amazonaws.com/geotrellis-test/usbuildings/afinkmiller-spark-pa02/{z}/{x}/{y}.mvt"],
             "minzoom": 15,
             "maxzoom": 15
         },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2.3'
+services:
+  us-buildings:
+    image: quay.io/azavea/openjdk-gdal:2.3.2-jdk8-slim
+    environment:
+      - AWS_PROFILE=geotrellis
+      - BINTRAY_USER=$BINTRAY_USER
+      - BINTRAY_PASS=$BINTRAY_PASS
+    volumes:
+      - ./:/opt/geotrellis-gdal
+      - $HOME/.aws:/root/.aws
+      - $HOME/tmp:/root/tmp
+      - $HOME/.ivy2:/root/.ivy2
+      - $HOME/.sbt:/root/.sbt
+      - $HOME/.coursier:/root/.coursier
+    working_dir: /opt/geotrellis-gdal
+    entrypoint: ./sbt 

--- a/src/main/scala/usbuildings/Building.scala
+++ b/src/main/scala/usbuildings/Building.scala
@@ -35,8 +35,11 @@ case class Building(file: String, idx: Int)(
     copy()(footprint, histogram, errors ++ List(err))
   }
 
-  def withHistogram(hist: Histogram[Double]): Building = {
-    copy()(footprint, Some(hist), errors)
+  def withHistogram(hist: Option[Histogram[Double]]): Building = {
+    if (!histogram.isEmpty && hist.isEmpty) {
+      print(s"WARNING: Overwriting with empty histogram for ($file, $idx)")
+    }
+    copy()(footprint, hist, errors)
   }
 
   def withFootprint(poly: Polygon): Building = {
@@ -49,7 +52,7 @@ case class Building(file: String, idx: Int)(
       val mergedHist = for (h1 <- histogram; h2 <- other.histogram) yield h1 merge h2
       mergedHist.orElse(histogram).orElse(other.histogram)
     }
-    withHistogram(hist.get)
+    withHistogram(hist)
   }
 }
 

--- a/src/main/scala/usbuildings/Building.scala
+++ b/src/main/scala/usbuildings/Building.scala
@@ -23,12 +23,12 @@ case class Building(file: String, idx: Int)(
   def id: (String, Int) = (file, idx)
 
   def toVectorTileFeature: Feature[Polygon, Map[String, vectortile.Value]] = {
-    val attributes = for {
+    val attributes = Map("errors" -> vectortile.VString(errors.mkString(", ")))
+    val histAttributes = for {
       hist <- histogram
       (min, max) <- hist.minMaxValues()
-    } yield Map("elevation_min" -> vectortile.VDouble(min), "elevation_max" -> vectortile.VDouble(max), "errors" -> vectortile.VString(errors.mkString(", ")))
-
-    Feature(footprint, attributes.getOrElse(Map.empty))
+    } yield Map("elevation_min" -> vectortile.VDouble(min), "elevation_max" -> vectortile.VDouble(max))
+    Feature(footprint, attributes ++ histAttributes.getOrElse(Map.empty))
   }
 
   def withError(err: String): Building = {

--- a/src/main/scala/usbuildings/BuildingsApp.scala
+++ b/src/main/scala/usbuildings/BuildingsApp.scala
@@ -59,7 +59,7 @@ class BuildingsApp(
                   polygon = building.footprint,
                   handler = CustomDoubleHistogramSummary)
 
-              (building.id, building.withHistogram(hist))
+              (building.id, building.withHistogram(Some(hist)))
             }
           }
         }

--- a/src/main/scala/usbuildings/BuildingsApp.scala
+++ b/src/main/scala/usbuildings/BuildingsApp.scala
@@ -2,6 +2,7 @@ package usbuildings
 
 import java.net.URL
 
+import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import geotrellis.proj4.{LatLng, WebMercator}
 import geotrellis.raster.summary.polygonal.{DoubleHistogramSummary, MaxSummary}
@@ -44,20 +45,23 @@ class BuildingsApp(
       val histPerTile =
         for {
           (tileKey, buildings) <- buildingsPartition.toArray.groupBy(_._1)
-          rasterSource = Terrain.getRasterSource(tileKey)
-          _ <- Try(rasterSource.extent).toOption.toList // filter out tiles that are not there
-          // it is three times slower to read the full tile vs just intersecting pixels
-          //raster <- rasterSource.read(tileKey.extent(Terrain.terrainTilesSkadiGrid)).toList
+          rasterSource = Either.catchNonFatal(Terrain.getRasterSource(tileKey))
           (_, building) <- buildings
-          raster <- rasterSource.read(building.footprint.envelope)
+          maybeRaster = rasterSource.flatMap(rs => Either.catchNonFatal(rs.read(building.footprint.envelope)))
         } yield {
-          val hist = raster.tile.band(bandIndex = 0)
-            .polygonalSummary(
-              extent = raster.extent,
-              polygon = building.footprint,
-              handler = CustomDoubleHistogramSummary)
+          maybeRaster match {
+            case Left(e: Throwable) => (building.id, building.withError(e.toString))
+            case Right(None) => (building.id, building.withError("Envelope not in RasterSource extent"))
+            case Right(Some(raster)) => {
+              val hist = raster.tile.band(bandIndex = 0)
+                .polygonalSummary(
+                  extent = raster.extent,
+                  polygon = building.footprint,
+                  handler = CustomDoubleHistogramSummary)
 
-          (building.id, building.withHistogram(hist))
+              (building.id, building.withHistogram(hist))
+            }
+          }
         }
 
       histPerTile.groupBy(_._1).mapValues(_.values.reduce(_ mergeHistograms  _)).toIterator

--- a/src/main/scala/usbuildings/Main.scala
+++ b/src/main/scala/usbuildings/Main.scala
@@ -1,6 +1,6 @@
 package usbuildings
 
-import java.net.URL
+import java.net.URI
 
 import com.monovore.decline.{CommandApp, Opts}
 import geotrellis.spark.io.kryo.KryoRegistrator
@@ -9,21 +9,31 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.{SparkConf, SparkContext}
 import cats.implicits._
 
+import scala.util.Properties
+
 object Main extends CommandApp(
   name = "geotrellis-usbuildings",
   header = "Collect building footprint elevations from terrain tiles",
   main = {
     val buildingsAllOpt = Opts.flag(long = "all-buildings", help = "Read all building footprints from hosted source.").orFalse
     val buildingsOpt = Opts.option[String]("buildings", help = "URI of the building shapes layers")
-    val outputOpt = Opts.option[String]("output", help = "URI prefix of output shapefiles")
+    val outputOpt = Opts.option[String]("output", help = "S3 URI prefix of output tiles").withDefault("s3://geotrellis-test/usbuildings/default")
     val layersOpt = Opts.options[String]("layer", help = "Layer to read exclusively, empty for all layers").orEmpty
 
-    (buildingsAllOpt, buildingsOpt, outputOpt, layersOpt).mapN { (buildingsAll, buildingsUri, outputUri, layers) =>
+    (buildingsAllOpt, buildingsOpt, outputOpt, layersOpt).mapN { (buildingsAll, buildingsUri, outputUriString, layers) =>
+      val outputUri = new URI(outputUriString)
+      if (outputUri.getScheme != "s3") {
+        throw new java.lang.IllegalArgumentException("--output must be an S3 URI")
+      }
+      val bucket = outputUri.getHost
+      val path = outputUri.getPath.stripPrefix("/")
+
       val conf = new SparkConf().
         setIfMissing("spark.master", "local[*]").
         setAppName("Building Footprint Elevation").
         set("spark.serializer", classOf[KryoSerializer].getName).
-        set("spark.kryo.registrator", classOf[KryoRegistrator].getName)
+        set("spark.kryo.registrator", classOf[KryoRegistrator].getName).
+        set("spark.executionEnv.AWS_PROFILE", Properties.envOrElse("AWS_PROFILE", "default"))
 
       implicit val ss: SparkSession = SparkSession.builder
         .config(conf)
@@ -37,9 +47,7 @@ object Main extends CommandApp(
         new BuildingsApp(List(buildingsUri))
       }
 
-      // TODO: use outputUri
-      GenerateVT.save(app.tiles, zoom= 15, "geotrellis-test", "usbuildings/vt02")
-
+      GenerateVT.save(app.tiles, zoom= 15, bucket, path)
     }
   }
 )


### PR DESCRIPTION
# Overview

This PR attempts to modify the US Buildings pipeline to trap and surface errors in the tile generation process. It then attaches the first of those errors to the building properties written to the vector tiles.

Since there are a relatively low number of errors and places we're trapping, I went with an Either based approach rather than the additional structure necessary to support Validated. A switch to Validated might be warranted if this initial effort surfaces a larger range of errors or printing multiple error messages is deemed to be worth the extra up front effort.

TODO:
- [x] Finish testing, ensure errors are visible
- [x] Add "show error text on feature hover" functionality

# Demo

<img width="1280" alt="screen shot 2019-03-06 at 1 39 12 pm" src="https://user-images.githubusercontent.com/1818302/53912071-5a995580-4015-11e9-9216-7e209f453011.png">

# Notes

## Docker Compose
I added a docker-compose.yml file to make local development, compilation and testing easier if a user doesn't have the appropriate Java bindings compiled into GDAL on their host machine.

## CLI implementations
I added an implementation here for the `--output` flag, with initial support for specifying an S3 URI. This has been super helpful in debugging and storing multiple test datasets without recompilation.

## Demo
I added a simple HTML demo to `./demo`. Repo users can copy the access-token.js.example and add their token without leaving unstaged changes in git.

# Testing

Start a Spark cluster, trigger a job with something like:
```
sparkSubmit --buildings https://usbuildingdata.blob.core.windows.net/usbuildings-v1-1/Pennsylvania.zip --output s3://bucket-name/path/prefix
```

Then add your key to the demo file, edit the tile URL in index.html and serve it with a local simple HTTP server. Zoom to anywhere in PA to view vector tiles with error info added.