### PR TITLE
Bootstrap GDAL 2.3 with public resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,16 @@ sbt:geotrellis-usbuildings> test:runMain usbuildings.Main --buildings https://us
 
 ### EMR
 
-Before running review `sbtlighter` configuration in `build.sbt`, `reload` SBT session if modified. Ensure you replace the S3 url for the `--output` parameter to point to a valid S3 path.
+At minimum, you'll need to change the following sbt lighter configuration variables in `build.sbt` 
+to resources within your AWS account before starting the EMR cluster:
+- `sparkS3JarFolder`: Must be an S3 path within the AWS account that the cluster can read/write to
+- `sparkS3LogUri`: Must be an S3 path within the AWS account that the cluster can read/write to
+- `sparkJobFlowInstancesConfig`: Must point to the EC2 key name you have access to
+
+Be sure to `reload` in sbt after making changes to `build.sbt`.
+
+When running the commands below, be sure you replace the S3 url for the `--output` parameter 
+to point to a valid S3 path that the EMR cluster has permissions to write to.
 
 ```
 sbt:geotrellis-usbuildings> sparkSubmit --all-buildings --buildings foo --output s3://bucket/path/prefix

--- a/build.sbt
+++ b/build.sbt
@@ -5,9 +5,12 @@ name := "geotrellis-usbuildings"
 scalaVersion := Version.scala
 scalaVersion in ThisBuild := Version.scala
 
-licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
+licenses := Seq(
+  "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 scalacOptions ++= Seq(
-  "-deprecation", "-unchecked", "-feature",
+  "-deprecation",
+  "-unchecked",
+  "-feature",
   "-language:implicitConversions",
   "-language:reflectiveCalls",
   "-language:higherKinds",
@@ -18,16 +21,20 @@ scalacOptions ++= Seq(
 )
 publishMavenStyle := true
 publishArtifact in Test := false
-pomIncludeRepository := { _ => false }
-addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.4" cross CrossVersion.binary)
-addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.1" cross CrossVersion.full)
+pomIncludeRepository := { _ =>
+  false
+}
+addCompilerPlugin(
+  "org.spire-math" % "kind-projector" % "0.9.4" cross CrossVersion.binary)
+addCompilerPlugin(
+  "org.scalamacros" %% "paradise" % "2.1.1" cross CrossVersion.full)
 dependencyUpdatesFilter := moduleFilter(organization = "org.scala-lang")
 resolvers ++= Seq(
   "geosolutions" at "http://maven.geo-solutions.it/",
   "locationtech-releases" at "https://repo.locationtech.org/content/groups/releases",
   "locationtech-snapshots" at "https://repo.locationtech.org/content/groups/snapshots",
   "osgeo" at "http://download.osgeo.org/webdav/geotools/",
-   Resolver.bintrayRepo("azavea", "geotrellis")
+  Resolver.bintrayRepo("azavea", "geotrellis")
 )
 
 libraryDependencies ++= Seq(
@@ -40,15 +47,15 @@ libraryDependencies ++= Seq(
   geotrellisGeotools,
   geotrellisVectorTile,
   "org.geotools" % "gt-ogr-bridj" % Version.geotools
-    exclude("com.nativelibs4java", "bridj"),
+    exclude ("com.nativelibs4java", "bridj"),
   "com.nativelibs4java" % "bridj" % "0.6.1",
   "com.azavea.geotrellis" %% "geotrellis-contrib-vlm" % "0.7.11-2.2",
-  "com.monovore"  %% "decline" % "0.5.1"
+  "com.monovore" %% "decline" % "0.5.1"
 )
 
 // auto imports for local dev console
 initialCommands in console :=
-"""
+  """
 import usbuildings._
 import java.net._
 import geotrellis.raster._
@@ -64,46 +71,61 @@ import geotrellis.contrib.vlm.gdal._
 Test / fork := true
 Test / parallelExecution := false
 Test / testOptions += Tests.Argument("-oD")
-Test / javaOptions ++= Seq("-Xms1024m", "-Xmx8144m", "-Djava.library.path=/usr/local/lib")
+Test / javaOptions ++= Seq("-Xms1024m",
+                           "-Xmx8144m",
+                           "-Djava.library.path=/usr/local/lib")
 
 // Settings for sbt-assembly plugin which builds fat jars for spark-submit
 assemblyMergeStrategy in assembly := {
-  case s if s.startsWith("META-INF/services") => MergeStrategy.concat
-  case "reference.conf" | "application.conf"  => MergeStrategy.concat
-  case "META-INF/MANIFEST.MF" | "META-INF\\MANIFEST.MF" => MergeStrategy.discard
-  case "META-INF/ECLIPSEF.RSA" | "META-INF/ECLIPSEF.SF" => MergeStrategy.discard
+  case "reference.conf"   => MergeStrategy.concat
+  case "application.conf" => MergeStrategy.concat
+  case PathList("META-INF", xs @ _*) =>
+    xs match {
+      case ("MANIFEST.MF" :: Nil) => MergeStrategy.discard
+      // Concatenate everything in the services directory to keep GeoTools happy.
+      case ("services" :: _ :: Nil) =>
+        MergeStrategy.concat
+      // Concatenate these to keep JAI happy.
+      case ("javax.media.jai.registryFile.jai" :: Nil) |
+          ("registryFile.jai" :: Nil) | ("registryFile.jaiext" :: Nil) =>
+        MergeStrategy.concat
+      case (name :: Nil) => {
+        // Must exclude META-INF/*.([RD]SA|SF) to avoid "Invalid signature file digest for Manifest main attributes" exception.
+        if (name.endsWith(".RSA") || name.endsWith(".DSA") || name.endsWith(
+              ".SF"))
+          MergeStrategy.discard
+        else
+          MergeStrategy.first
+      }
+      case _ => MergeStrategy.first
+    }
   case _ => MergeStrategy.first
 }
 
 // Settings from sbt-lighter plugin that will automate creating and submitting this job to EMR
 import sbtlighter._
 
-sparkEmrRelease             := "emr-5.13.0"
-sparkAwsRegion              := "us-east-1"
-sparkEmrApplications        := Seq("Spark", "Zeppelin", "Ganglia")
-sparkEmrBootstrap           := List(
-  BootstrapAction(
-    "GIS", "s3://geotrellis-test/eac/bootstrap-geopyspark.sh",
-    "s3://geopyspark-resources/rpms/86d70ff7d21b74e2dfea6ec395a4564d713d44ee",
-    "s3://geopyspark-resources/notebooks",
-    "github",
-    "LocalGitHubOAuthenticator",
-    "51c3c12344d06e2b0850",
-    "c7b608e3be66ae4332c88db21cae3f4a47313535",
-    "s3://geopyspark-resources/jars/read-to-layout-improved-test.jar",
-    "https://github.com/jbouffard/geopyspark/archive/cf381434a9d05f8286dea27c353df4b03f4e4fdd.zip"))
-sparkS3JarFolder            := "s3://geotrellis-test/usbuildings/jars"
-sparkInstanceCount          := 20
-sparkMasterType             := "m4.xlarge"
-sparkCoreType               := "m4.xlarge"
-sparkMasterPrice            := Some(0.5)
-sparkCorePrice              := Some(0.5)
-sparkClusterName            := s"geotrellis-usbuildings"
-sparkEmrServiceRole         := "EMR_DefaultRole"
-sparkInstanceRole           := "EMR_EC2_DefaultRole"
-sparkJobFlowInstancesConfig := sparkJobFlowInstancesConfig.value.withEc2KeyName("geotrellis-emr")
-sparkS3LogUri               := Some("s3://geotrellis-test/usbuildings/logs")
-sparkEmrConfigs             := List(
+sparkEmrRelease := "emr-5.13.0"
+sparkAwsRegion := "us-east-1"
+sparkEmrApplications := Seq("Spark", "Zeppelin", "Ganglia")
+sparkEmrBootstrap := List(
+  BootstrapAction("Install GDAL + dependencies",
+                  "s3://geotrellis-test/usbuildings/bootstrap.sh",
+                  "s3://geotrellis-test/usbuildings",
+                  "v1.0"))
+sparkS3JarFolder := "s3://geotrellis-test/usbuildings/jars"
+sparkInstanceCount := 20
+sparkMasterType := "m4.xlarge"
+sparkCoreType := "m4.xlarge"
+sparkMasterPrice := Some(0.5)
+sparkCorePrice := Some(0.5)
+sparkClusterName := s"geotrellis-usbuildings"
+sparkEmrServiceRole := "EMR_DefaultRole"
+sparkInstanceRole := "EMR_EC2_DefaultRole"
+sparkJobFlowInstancesConfig := sparkJobFlowInstancesConfig.value.withEc2KeyName(
+  "geotrellis-emr")
+sparkS3LogUri := Some("s3://geotrellis-test/usbuildings/logs")
+sparkEmrConfigs := List(
   EmrConfig("spark").withProperties(
     "maximizeResourceAllocation" -> "true"
   ),

--- a/demo/index.html
+++ b/demo/index.html
@@ -29,10 +29,8 @@ var popup = new mapboxgl.Popup({
 });
 
 map.on('load', function() {
-    // Add Mapillary sequence layer.
-    // https://www.mapillary.com/developer/tiles-documentation/#sequence-layer
     map.addLayer({
-        "id": "mapillary",
+        "id": "usbuildings",
         "type": "fill",
         "source": {
             "type": "vector",
@@ -53,28 +51,30 @@ map.on('load', function() {
     }, 'waterway-label');
 });
 
-map.on("mouseenter", "mapillary", function(e) {
-    map.getCanvas().style.cursor = 'pointer';
+map.on("mouseenter", "usbuildings", function(e) {
     if (e.features && e.features[0] && e.features[0].properties) {
         var feature = e.features[0];
         var props = feature.properties;
+        var coordinates = feature.geometry.coordinates[0][0].slice();
         var osm_info = {
             "min": props["elevation_min"],
             "max": props["elevation_max"]
         };
+        var html = '';
         if (props.errors) {
             osm_info["errors"] = props["errors"]
-            var coordinates = feature.geometry.coordinates[0][0].slice();
-            popup.setLngLat(coordinates);
-            popup.setHTML(props["errors"]);
-            popup.addTo(map);
-        }
+            html = props["errors"];
+        } else {
+            html = "Min: " + osm_info["min"] + "<br />Max:" + osm_info["max"];
+	}
+        popup.setLngLat(coordinates);
+        popup.setHTML(html);
+        popup.addTo(map);
         console.log(osm_info)
     }
 });
 
-map.on("mouseleave", "mapillary", function (e) {
-    map.getCanvas().style.cursor = '';
+map.on("mouseleave", "usbuildings", function (e) {
     popup.remove();
 });
 


### PR DESCRIPTION
Updates the bootstrap script to be a public one versioned for this demo. RPMs are also public and come from the same bucket to keep all project resources in one place. 

I added a note to the README that indicates that folks interested in running the demo will need to change a few spark configuration variables in build.sbt before creating their cluster, so watch out for that.

I was able to successfully run a test job for Rhode Island buildings with:
```
sparkSubmit --buildings https://usbuildingdata.blob.core.windows.net/usbuildings-v1-1/RhodeIsland.zip --output s3://geotrellis-test/usbuildings/afinkmiller-spark-ri-03
```

![Screen Shot 2019-04-18 at 8 54 04 AM](https://user-images.githubusercontent.com/1818302/56363499-618db900-61ba-11e9-9414-1da746493cde.png)

**Other:** 
- Updated the mergeAssemblyStrategy to our latest known good configuration.
- Tweaked the demo HTML to increase naming consistency
- Removes what looks like some OAuth credentials... @echeipesh you might want to rotate those...
